### PR TITLE
Update OAuthSeeder.php

### DIFF
--- a/database/seeds/OAuthSeeder.php
+++ b/database/seeds/OAuthSeeder.php
@@ -11,8 +11,8 @@ class OAuthSeeder extends Seeder {
         app('db')->table("oauth_clients")->delete();
 
         app('db')->table("oauth_clients")->insert([
-            'id' => $config->get('secrets.client_id'),
-            'secret' => $config->get('secrets.client_secret'),
+            'id' => $config->get('app.client_id'),
+            'secret' => $config->get('app.client_secret'),
             'name' => 'Lumen Api Starter'
         ]);
     }


### PR DESCRIPTION
 [Illuminate\Database\QueryException]
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'id' cannot be null (SQL: insert into `oauth_clients` (`id`, `secret`, `name`) values (, , Lumen Api Starter))

Change secrets into app.
